### PR TITLE
docker-compose.ymlを作成

### DIFF
--- a/docker-wordpress/docker-compose.yml
+++ b/docker-wordpress/docker-compose.yml
@@ -1,0 +1,47 @@
+
+version: '3.8'
+
+services:
+  db:
+    image: mariadb:latest
+    container_name: wordpress_db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wpuser
+      MYSQL_PASSWORD: wppass
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:latest
+    container_name: wordpress_app
+    # ComposeはDBを起動してから、WPを起動する
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    restart: always
+    # WPコンテナに渡す環境変数
+    # WPがDBに接続する際に使う
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wpuser
+      WORDPRESS_DB_PASSWORD: wppass
+    # ホスト側とコンテナ内のフォルダをマウントする
+    volumes:
+      - wp_data:/var/www/html
+
+volumes:
+  db_data:
+  wp_data:
+
+
+# Docker Composeは db（MariaDB） → wordpress の順で起動
+
+# WordPressは環境変数を使って db に接続
+
+# データは db_data, wp_data というボリュームに保存され、コンテナを削除しても残る
+


### PR DESCRIPTION
## なぜやるのか
WordPressの環境をDocker Composeで構築し、インフラ構成を理解する演習のため。

## なにをやったか
WordPressとMariaDBを構成する docker-compose.yml を追加
必要なサービス・環境変数・ボリュームを設定

## 動作確認の手順

1. ディレクトリに移動する
`cd docker-wordpress
`
2. コンテナを起動する
`docker compose up -d
`
3. ブラウザからアクセス
`http://localhost:8080
`
4. コンテナの削除
ボリュームとイメージは残るが、コンテナは削除される
`docker compose down
`

## スクリーンショット
<img width="1120" alt="2025-06-24_15h36_44" src="https://github.com/user-attachments/assets/8986ae04-ebd6-4e92-97ad-20666da54fed" />
<img width="1120" alt="2025-06-24_15h37_18" src="https://github.com/user-attachments/assets/d2b6318c-c9b8-4dc4-ab90-276ea4608961" />

